### PR TITLE
skill説明のmargin削除

### DIFF
--- a/src/components/molecule/TextBox.astro
+++ b/src/components/molecule/TextBox.astro
@@ -10,6 +10,7 @@ const { maxWidth } = Astro.props
 
 <style define:vars={{ maxWidth }}>
   p {
+    margin: 0;
     text-align: center;
     max-width: var(--maxWidth);
     word-break: keep-all;


### PR DESCRIPTION
marginが残っており、不自然な隙間が発生していたので削除した。