### PR TITLE
下部のスクロースバーが出ないように

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -34,7 +34,7 @@ const { location, title } = Astro.props;
   @import "../styles/reset.css";
   body {
     margin: 0;
-    width: 100vw;
+    width: 100%;
     display: flex;
     flex-direction: column;
     justify-content: start;


### PR DESCRIPTION
100vwを使っていた影響で下部にスクロールバーが出てしまっていたので、100%へ変更することで出ないようにした。